### PR TITLE
fix: Use Corepack to manage Yarn version in GitHub workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
+          cache: 'yarn'
+      - name: Enable Corepack
+        run: corepack enable
       - run: yarn install
       - run: yarn test
       - run: yarn build


### PR DESCRIPTION
The previous workflow was failing due to a mismatch between the global Yarn version in the GitHub Actions runner and the version specified in package.json.

This change updates the workflow to:
- Enable Corepack using `corepack enable` before running yarn commands. This ensures the project-specified Yarn version is used.
- Enable Yarn caching in the `setup-node` action for potentially faster builds.

This will prevent the "packageManager" field error and make the workflow more resilient to future Yarn version changes.