### PR TITLE
Expand "Do not use Go like Java" post with detailed examples

### DIFF
--- a/src/posts/2020-08-18-do-not-use-go-like-java/index.md
+++ b/src/posts/2020-08-18-do-not-use-go-like-java/index.md
@@ -48,7 +48,34 @@ Adding a new method to `SomeService` now has zero impact on consumers or their t
 
 ## The Java-Style Mistake
 
-A common pattern for Go developers coming from Java. The producer defines an interface and returns it:
+A common pattern for Go developers coming from Java. The producer owns the interface — every consumer depends on it:
+
+```
+┌─────────────────────────────────────────┐
+│              producer.go                │
+│                                         │
+│  «interface»                            │
+│  SomeService  ◄─────────────────────┐  │
+│  DoSomething()                       │  │
+│       △                              │  │
+│       │ implements                   │  │
+│  someServiceImpl                     │  │
+└─────────────────────────────────────────┘
+          │ returns SomeService
+          ▼
+┌──────────────────┐   ┌──────────────────┐
+│   consumer.go    │   │ consumer_test.go  │
+│                  │   │                  │
+│ depends on       │   │ someMockService   │
+│ SomeService ─────┼───┼──► must implement│
+│                  │   │    SomeService   │
+└──────────────────┘   └──────────────────┘
+
+  Adding a method to SomeService forces
+  changes in ALL files above  ⚠️
+```
+
+The producer defines an interface and returns it:
 
 ```go
 type SomeService interface {
@@ -104,6 +131,35 @@ Adding a new method to `SomeService` breaks every consumer and every mock:
 Because the interface is defined on the producer side, every file that depends on it — including test mocks — must be updated. The more consumers you have, the worse this gets.
 
 ## The Fix
+
+Each consumer owns its own interface — the producer knows nothing about them:
+
+```
+┌─────────────────────────────────────────┐
+│              producer.go                │
+│                                         │
+│  SomeService struct                     │
+│  DoSomething()                          │
+│  DoOtherThing()   ← add freely, no     │
+│                     downstream breakage │
+└─────────────────────────────────────────┘
+          │ returns *SomeService
+          │ (concrete type)
+          ▼
+┌──────────────────┐   ┌──────────────────┐
+│   consumer.go    │   │  other_consumer  │
+│                  │   │                  │
+│ «interface»      │   │ «interface»      │
+│ SomethingDoer    │   │ Doer             │
+│ DoSomething() ◄──┘   │ DoSomething() ◄──┘
+│                  │   │                  │
+│ only what it     │   │ only what it     │
+│ needs            │   │ needs            │
+└──────────────────┘   └──────────────────┘
+
+  Each consumer is isolated. ✓
+  Adding methods to producer affects nobody.
+```
 
 Two rules:
 

--- a/src/posts/2020-08-18-do-not-use-go-like-java/index.md
+++ b/src/posts/2020-08-18-do-not-use-go-like-java/index.md
@@ -1,10 +1,54 @@
 ---
-title: Do not use Go like Java
-keywords: go, golang
+title: "Do not use Go like Java"
+description: Go interfaces belong on the consumer side, not the producer side. Learn the "accept interfaces, return structs" principle.
+keywords: go, golang, interfaces
 date: 2020-08-18T22:29:09-07:00
 ---
 
-I have been using Go in the following way (like Java)
+The problem: defining interfaces on the producer side (Java-style) creates tight coupling. Every new method breaks every consumer and every test mock.
+
+The solution: **accept interfaces, return structs.** Producers return concrete types. Consumers define their own small interfaces.
+
+## TLDR
+
+**Bad — Java-style (interface on producer side):**
+
+```go
+// producer.go
+type SomeService interface {
+	DoSomething() string
+}
+
+func NewSomeService() SomeService {
+	return &someServiceImpl{}
+}
+```
+
+**Good — Go-style (interface on consumer side):**
+
+```go
+// producer.go — returns a concrete struct
+type SomeService struct{}
+
+func NewSomeService() *SomeService {
+	return &SomeService{}
+}
+
+// consumer.go — defines only what it needs
+type SomethingDoer interface {
+	DoSomething() string
+}
+
+func NewAnotherService(doer SomethingDoer) *AnotherService {
+	return &AnotherService{doer}
+}
+```
+
+Adding a new method to `SomeService` now has zero impact on consumers or their tests.
+
+## The Java-Style Mistake
+
+A common pattern for Go developers coming from Java. The producer defines an interface and returns it:
 
 ```go
 type SomeService interface {
@@ -23,7 +67,7 @@ func (*someServiceImpl) DoSomething() string {
 }
 ```
 
-And from a consumer side, it just refers to the interfaces so that I can swap with a mock struct anytime.
+The consumer depends on that interface. Tests use a mock that implements it:
 
 ```go
 func NewAnotherService(someService SomeService) AnotherService {
@@ -40,7 +84,9 @@ func TestAnotherService(t *testing.T) {
 }
 ```
 
-But then the problem occurs when I want to add a new method to `SomeService`.
+## Why This Breaks
+
+Adding a new method to `SomeService` breaks every consumer and every mock:
 
 ```diff
  type SomeService interface {
@@ -55,31 +101,31 @@ But then the problem occurs when I want to add a new method to `SomeService`.
 + }
 ```
 
-Now I have to refactor everywhere including the test files (e.g., `anotherservice_test.go`)!
+Because the interface is defined on the producer side, every file that depends on it — including test mocks — must be updated. The more consumers you have, the worse this gets.
 
-## What should I have done
+## The Fix
 
-Ok, so what should I have done is
+Two rules:
 
-- producers should return a concrete type.
-- define interface in the consumer and only define what is used.
+- **Producers return concrete types.** No interface on the producer side.
+- **Consumers define their own interfaces.** Each consumer declares only the methods it needs.
 
-For example,
+The producer returns a struct:
 
 ```go
 // producer.go
 type SomeService struct{}
 
-func NewSomeService() SomeService {
+func NewSomeService() *SomeService {
 	return &SomeService{}
 }
 
-func (s SomeService) DoSomething() string {
+func (s *SomeService) DoSomething() string {
 	return "some-service"
 }
 ```
 
-And used in the client/consumer,
+The consumer defines a small interface with only the methods it needs:
 
 ```go
 // consumer.go
@@ -87,27 +133,39 @@ type SomethingDoer interface {
 	DoSomething() string
 }
 
-func NewAnotherService(doer SomethingDoer) AnotherService {
+func NewAnotherService(doer SomethingDoer) *AnotherService {
 	return &AnotherService{doer}
 }
 ```
 
-Now notice that even if I add a new method to `SomeService`, the consumer is not affected.
+Adding a method to the producer has zero impact on the consumer:
 
 ```diff
   // producer.go
   type SomeService struct{}
 
-  func NewSomeService() SomeService {
+- func NewSomeService() SomeService {
++ func NewSomeService() *SomeService {
     return &SomeService{}
   }
 
-  func (s SomeService) DoSomething() string {
+- func (s SomeService) DoSomething() string {
++ func (s *SomeService) DoSomething() string {
     return "some-service"
   }
 
-+ // this change won't affect `consumer.go`
-+ func (s SomeService) DoAnotherThing() {
++ // this change won't affect consumer.go
++ func (s *SomeService) DoAnotherThing() {
 +   fmt.Println("some-service")
 + }
 ```
+
+## Why This Matters
+
+- **Loose coupling.** Producers evolve independently. New methods never break existing consumers.
+- **Easier testing.** Mocks implement only the methods the test cares about, not an entire interface.
+- **Smaller interfaces.** Go's standard library follows this pattern — `io.Reader` is one method, `io.Writer` is one method. As Rob Pike says: *"The bigger the interface, the weaker the abstraction."*
+
+This is also the official recommendation from the [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments#interfaces):
+
+> Go interfaces generally belong in the package that uses values of the interface type, not the package that implements those values.


### PR DESCRIPTION
## Summary
Significantly expanded the blog post about Go interface design patterns to provide comprehensive guidance on the "accept interfaces, return structs" principle. The post now includes visual diagrams, detailed before/after comparisons, and explanations of why the Java-style approach breaks down in Go.

## Key Changes

- **Added metadata**: Enhanced frontmatter with a description and additional keywords for better discoverability
- **Added TLDR section**: Quick side-by-side comparison of bad (Java-style) vs. good (Go-style) patterns
- **Added visual diagrams**: ASCII diagrams showing dependency flow in both approaches to illustrate the coupling problem
- **Restructured content**: Reorganized sections with clearer headings ("The Java-Style Mistake", "Why This Breaks", "The Fix", "Why This Matters")
- **Expanded examples**: More complete code examples showing concrete types, pointer receivers, and consumer-side interface definitions
- **Added rationale**: Explanation of why the Java-style approach causes cascading changes when adding methods
- **Added authority**: Included reference to official Go Code Review Comments guidelines
- **Improved clarity**: Rewrote explanations to be more direct and actionable, with emphasis on the core principle that producers return concrete types while consumers define their own small interfaces

## Notable Details

The post now clearly demonstrates:
- How adding a method to a producer-side interface forces updates in all consumers and test mocks
- How the Go-style approach isolates changes to the producer only
- The connection to Go's standard library philosophy (small, focused interfaces like `io.Reader`)
- Practical code patterns with pointer receivers and proper return types

https://claude.ai/code/session_01Dc23FDcekE1U3dhfvVh9jW